### PR TITLE
feat: add enabled flag for MCP agents

### DIFF
--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/MCPAgentModal.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/MCPAgentModal.tsx
@@ -16,6 +16,7 @@ const DEFAULT_AGENT: MCPAgentConfig = {
   model_context_token_limit: undefined,
   tool_call_summary_format: "{tool_name}({arguments}): {result}",
   model_client: DEFAULT_OPENAI,
+  enabled: true,
 };
 
 interface MCPAgentModalProps {

--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/MCPAgentsSettings.tsx
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/MCPAgentsSettings.tsx
@@ -16,6 +16,7 @@ const DEFAULT_AGENT: MCPAgentConfig = {
   model_context_token_limit: undefined,
   tool_call_summary_format: "{tool_name}({arguments}): {result}",
   model_client: DEFAULT_OPENAI,
+  enabled: true,
 };
 
 export interface MCPAgentsSettingsProps extends SettingsTabProps {

--- a/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/types.ts
+++ b/frontend/src/components/settings/tabs/agentSettings/mcpAgentsSettings/types.ts
@@ -10,6 +10,7 @@ export const MCPAgentConfigSchema = z.object({
   model_context_token_limit: z.number().optional(),
   tool_call_summary_format: z.string().optional(),
   model_client: ModelConfigSchema,
+  enabled: z.boolean().optional().default(true),
 });
 
 export type MCPAgentConfig = z.infer<typeof MCPAgentConfigSchema>;

--- a/src/magentic_ui/agents/mcp/_config.py
+++ b/src/magentic_ui/agents/mcp/_config.py
@@ -6,6 +6,7 @@ from ...tools.mcp import NamedMcpServerParams
 
 
 class McpAgentConfig(AssistantAgentConfig):
+    enabled: bool = True
     mcp_servers: List[NamedMcpServerParams]
     model_context_token_limit: int | None = None
     tool_call_summary_format: str = "{tool_name}({arguments}): {result}"

--- a/src/magentic_ui/task_team.py
+++ b/src/magentic_ui/task_team.py
@@ -223,6 +223,7 @@ async def get_task_team(
         # TODO: Init from constructor?
         McpAgent._from_config(config)  # type: ignore
         for config in magentic_ui_config.mcp_agent_configs
+        if config.enabled
     ]
 
     if (


### PR DESCRIPTION
## Summary
- add `enabled` option to MCP agent configuration with default `true`
- include `enabled` in frontend MCP agent schema and defaults
- ignore disabled MCP agents when building task team

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `npm run typecheck` *(fails: Cannot find module 'js-yaml', type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a54f915280832b9139d8a7741961df