### PR TITLE
feat: add MCP agent selector

### DIFF
--- a/frontend/src/components/views/chat/ActiveAgentsSelector.tsx
+++ b/frontend/src/components/views/chat/ActiveAgentsSelector.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Checkbox } from "antd";
+
+interface AgentConfig {
+  name: string;
+  [key: string]: any;
+}
+
+interface ActiveAgentsSelectorProps {
+  agents: AgentConfig[];
+  selectedAgents: string[];
+  onChange: (agents: string[]) => void;
+}
+
+const ActiveAgentsSelector: React.FC<ActiveAgentsSelectorProps> = ({
+  agents,
+  selectedAgents,
+  onChange,
+}) => {
+  if (!agents || agents.length === 0) return null;
+
+  const options = agents.map((agent) => ({
+    label: agent.name,
+    value: agent.name,
+  }));
+
+  return (
+    <div className="mb-2">
+      <Checkbox.Group
+        options={options}
+        value={selectedAgents}
+        onChange={(list) => onChange(list as string[])}
+      />
+    </div>
+  );
+};
+
+export default ActiveAgentsSelector;
+

--- a/frontend/src/components/views/chat/runview.tsx
+++ b/frontend/src/components/views/chat/runview.tsx
@@ -9,6 +9,7 @@ import ApprovalButtons from "./approval_buttons";
 import ChatInput from "./chatinput";
 import { IStatus } from "../../types/app";
 import { RcFile } from "antd/es/upload";
+import ActiveAgentsSelector from "./ActiveAgentsSelector";
 
 const DETAIL_VIEWER_CONTAINER_ID = "detail-viewer-container";
 
@@ -37,6 +38,9 @@ interface RunViewProps {
   chatInputRef?: React.RefObject<any>;
   onExecutePlan?: (plan: IPlan) => void;
   enable_upload?: boolean;
+  agents: any[];
+  selectedAgents: string[];
+  onSelectedAgentsChange: (agents: string[]) => void;
 }
 
 const RunView: React.FC<RunViewProps> = ({
@@ -59,6 +63,9 @@ const RunView: React.FC<RunViewProps> = ({
   chatInputRef,
   onExecutePlan,
   enable_upload = false,
+  agents,
+  selectedAgents,
+  onSelectedAgentsChange,
 }) => {
   const threadContainerRef = useRef<HTMLDivElement | null>(null);
   const [novncPort, setNovncPort] = useState<string | undefined>();
@@ -667,6 +674,11 @@ const RunView: React.FC<RunViewProps> = ({
             width: "100%", // Always take full width of parent
           }}
         >
+          <ActiveAgentsSelector
+            agents={agents}
+            selectedAgents={selectedAgents}
+            onChange={onSelectedAgentsChange}
+          />
           <ChatInput
             ref={chatInputRef}
             onSubmit={(


### PR DESCRIPTION
## Summary
- add ActiveAgentsSelector component for choosing MCP agents
- filter settings config by selected agents when sending messages
- surface agent selector in chat view and run view

## Testing
- `npm --prefix frontend run typecheck`
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68a560fd1844832bbcdf159e82f157dd