### PR TITLE
Fix UrlStatusManager handling of empty configuration

### DIFF
--- a/src/magentic_ui/tools/url_status_manager.py
+++ b/src/magentic_ui/tools/url_status_manager.py
@@ -38,10 +38,14 @@ class UrlStatusManager:
         """
         self.url_statuses = None
         # a little bit of a hack to make sure there are no trailing slashes, since they mess with the comparison later on
-        if url_statuses is not None:
-            self.url_statuses = {
-                key.rstrip("/"): value for key, value in url_statuses.items()
-            }
+        if url_statuses:
+            cleaned = {key.rstrip("/"): value for key, value in url_statuses.items()}
+            # Treat an empty dictionary the same as not providing any
+            # URL statuses.  Without this, passing an empty dict would
+            # result in no URL ever being allowed since the checks below
+            # expect ``None`` to represent "allow all" semantics.
+            if cleaned:
+                self.url_statuses = cleaned
 
         self.url_block_list = url_block_list
 

--- a/tests/test_url_status_manager.py
+++ b/tests/test_url_status_manager.py
@@ -46,3 +46,13 @@ async def test_url_status_manager():
     assert not url_status_manager.is_url_allowed("sample.com")
     assert not url_status_manager.is_url_allowed("sample.com/foo")
     assert not url_status_manager.is_url_allowed("sample.com/bar")
+
+
+@pytest.mark.asyncio
+async def test_empty_url_statuses_allow_all():
+    """An empty url_statuses dict should behave the same as None (allow all)."""
+
+    url_status_manager = UrlStatusManager(url_statuses={})
+
+    assert url_status_manager.is_url_allowed("http://example.com")
+    assert url_status_manager.is_url_allowed("https://another.example")


### PR DESCRIPTION
## Summary
- Treat empty `url_statuses` dict the same as `None` to allow all URLs
- Add regression test ensuring empty configuration permits any URL

## Testing
- `uv run pytest tests/test_url_status_manager.py tests/test_aggregate_mcp_workbench.py tests/test_magentic_ui_config_serialization.py -m "not npx" -q`
- ⚠️ `uv run poe test` (playwright download blocked)


------
https://chatgpt.com/codex/tasks/task_e_68a563895ed8832bb60684db4e76889f